### PR TITLE
Try to shorten the release install path a bit

### DIFF
--- a/main.js
+++ b/main.js
@@ -203,15 +203,12 @@ async function run() {
 
     const input = parseInput();
 
-    const dest = path.join(tmp_dir, 'msys');
-    await io.mkdirP(dest);
-
     let cachedInstall = false;
     let instCache = null;
     let msysRootDir = path.join('C:', 'msys64');
     if (input.release) {
       // Use upstream package instead of the default installation in the virtual environment.
-      msysRootDir = path.join(dest, 'msys64');
+      msysRootDir = path.join(tmp_dir, 'msys64');
 
       if (INSTALL_CACHE_ENABLED) {
         instCache = new InstallCache(msysRootDir, input);
@@ -225,7 +222,7 @@ async function run() {
         let inst_dest = await downloadInstaller();
 
         changeGroup('Extracting MSYS2...');
-        await exec.exec(inst_dest, ['-y'], {cwd: dest});
+        await exec.exec(inst_dest, ['-y'], {cwd: tmp_dir});
 
         changeGroup('Disable Key Refresh...');
         await disableKeyRefresh(msysRootDir);
@@ -233,8 +230,10 @@ async function run() {
       }
     }
 
-    writeWrapper(msysRootDir, input.pathtype, dest, 'msys2.cmd');
-    core.addPath(dest);
+    const pathDir = path.join(tmp_dir, 'setup-msys2');
+    await io.mkdirP(pathDir);
+    writeWrapper(msysRootDir, input.pathtype, pathDir, 'msys2.cmd');
+    core.addPath(pathDir);
 
     core.exportVariable('MSYSTEM', input.msystem);
 


### PR DESCRIPTION
We created a "msys" dir under RUNNER_TEMP and then added the launcher
there and install msys2 under "msys64".

This results in an install path of "D:/a/_temp/msys/msys64". Since these paths
might end up in command line arguments and those have length limits we should
try to keep it short.

So install the launcher under "$RUNNER_TEMP/setup-msys2" and msys2 directly
under "$RUNNER_TEMP/msys64", so the path becomes "D:/a/_temp/msys64",
saving 5 characters.

This is motivated by a qt6 build error hitting the limit. Tough not sure if this is enough of a reduction to make it work... https://github.com/msys2/MINGW-packages/pull/9716