### PR TITLE
Don't abort when run on Linux / Mac OS.

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -356,3 +356,21 @@ jobs:
     - shell: msys2 {0}
       run: |
         uname -a
+
+
+  platformchecks:
+    needs: [cache]
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ macos, ubuntu ]
+    runs-on: ${{ matrix.platform }}-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/download-artifact@v2
+      with:
+        name: action
+    - name: run action
+      uses: ./
+      with:
+        platform-check-severity: warn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/msys2/setup-msys2/compare/a3cc4d82700448fea6cb3bcfc9cbb23f916762c4...HEAD)
 
+### Added
+
+- Option: `platform-check-severity`. [[msys2/setup-msys2](https://github.com/msys2/setup-msys2/pull/172)]
+
 ### Changed
 
 - Bump dependencies:

--- a/README.md
+++ b/README.md
@@ -211,3 +211,13 @@ The package or list of packages are installed through `pacman --noconfirm -S --n
         git
         base-devel
 ```
+#### platform-check-severity
+
+By default (`fatal`), throw an error if the runner OS is not Windows.
+If set to `warn`, simply log a message and skip the rest:
+
+```yaml
+  - uses: msys2/setup-msys2@v2
+    with:
+      platform-check-severity: warn
+```

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,10 @@ inputs:
     description: 'Install packages after installation through pacman'
     required: false
     default: false
+  platform-check-severity:
+    description: 'What to do when run on an incompatible runner: fatal, warn'
+    required: false
+    default: 'fatal'
 runs:
   using: 'node12'
   main: 'index.js'


### PR DESCRIPTION
I am trying to call this action from another composite action, one that
is supposed to be working for Linux, Mac OS, and Windows.

Ideally one would put the `uses` statement behind a conditional
expression, like:

    - uses: msys2/setup-msys2@v2
      if: runner.os == 'Windows'

However, composite actions do not support conditional steps yet (see:
https://github.com/actions/runner/issues/834), so the only way to keep
the setup-msys2 step inside my action (and not forcing the wokflow to
use it instead), is to suppress the error message (It's OK to log it,
but it should not fail).