### PR TITLE
Remove folder-hash dependency

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -21,6 +21,7 @@ jobs:
         persist-credentials: false
     - run: |
         npm ci
+        npm run test
         npm run lint
         npm run tsc
 

--- a/main.js
+++ b/main.js
@@ -8,7 +8,7 @@ import fs from 'node:fs';
 import crypto from 'node:crypto';
 import assert from 'node:assert/strict';
 import process from 'node:process';
-import { hashElement } from 'folder-hash';
+import { hashPath } from './src/fs-hash.js';
 
 // XXX: hack to make ncc copy those files to dist
 // eslint-disable-next-line
@@ -183,14 +183,6 @@ async function restoreCache(paths, primaryKey, restoreKeys) {
     }
 
     return restoreKey;
-}
-
-/**
- * @param {string} path
- * @returns {Promise<string>}
- */
-async function hashPath(path) {
-  return (await hashElement(path, {encoding: 'hex'}))['hash'].toString();
 }
 
 class PackageCache {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,7 @@
         "@actions/cache": "^4.1.0",
         "@actions/core": "^1.11.1",
         "@actions/exec": "^1.1.1",
-        "@actions/tool-cache": "^2.0.2",
-        "folder-hash": "^4.1.1"
+        "@actions/tool-cache": "^2.0.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.37.0",
@@ -1282,59 +1281,6 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true
-    },
-    "node_modules/folder-hash": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/folder-hash/-/folder-hash-4.1.1.tgz",
-      "integrity": "sha512-1ZSlKJSbET3XpglnEXC9g+QF4QRZhqHIjpFfa4pAMfO4tu/XYPafpeHEX6zOFS2EolOIXr0lPh1eSjmdWItX2w==",
-      "dependencies": {
-        "debug": "4.4.0",
-        "minimatch": "7.4.6"
-      },
-      "bin": {
-        "folder-hash": "bin/folder-hash"
-      },
-      "engines": {
-        "node": ">=10.10.0"
-      }
-    },
-    "node_modules/folder-hash/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/folder-hash/node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/folder-hash/node_modules/minimatch": {
-      "version": "7.4.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
-      "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/form-data": {
       "version": "2.5.5",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "pkg": "ncc build main.js --minify --out dist",
     "lint": "eslint .",
-    "tsc": "tsc -p jsconfig.json"
+    "tsc": "tsc -p jsconfig.json",
+    "test": "node --test"
   },
   "keywords": [
     "GitHub",
@@ -31,8 +32,7 @@
     "@actions/cache": "^4.1.0",
     "@actions/core": "^1.11.1",
     "@actions/exec": "^1.1.1",
-    "@actions/tool-cache": "^2.0.2",
-    "folder-hash": "^4.1.1"
+    "@actions/tool-cache": "^2.0.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.37.0",

--- a/src/fs-hash.js
+++ b/src/fs-hash.js
@@ -1,0 +1,76 @@
+import fs from "node:fs";
+import path from "node:path";
+import { createHash } from "node:crypto";
+
+/**
+ * @param {string} inputPath
+ * @returns {Promise<string>}
+ */
+export async function hashPath(inputPath) {
+  const stats = await fs.promises.stat(inputPath);
+  
+  if (stats.isFile()) {
+    return hashFile(inputPath);
+  } else if (stats.isDirectory()) {
+    return hashDirectory(inputPath);
+  } else {
+    throw new Error(`Unsupported path type: ${inputPath}`);
+  }
+}
+
+/**
+ * @param {string} filePath
+ * @returns {Promise<string>}
+ */
+async function hashFile(filePath) {
+  const hash = createHash("sha256");
+  const fileName = path.basename(filePath);
+
+  hash.update(fileName);
+
+  await new Promise((resolve, reject) => {
+    const stream = fs.createReadStream(filePath);
+    stream.on("data", (chunk) => hash.update(chunk));
+    stream.on("end", () => resolve());
+    stream.on("error", reject);
+  });
+  
+  return hash.digest("hex");
+}
+
+/**
+ * @param {string} dirPath
+ * @returns {Promise<string>}
+ */
+async function hashDirectory(dirPath) {
+  const hash = createHash("sha256");
+  const dirName = path.basename(dirPath);
+
+  hash.update(dirName);
+
+  const entries = await fs.promises.readdir(dirPath, {
+    withFileTypes: true,
+  });
+
+  entries.sort((a, b) => a.name.localeCompare(b.name));
+
+  for (const entry of entries) {
+    const fullPath = path.join(dirPath, entry.name);
+
+    hash.update(entry.name);
+
+    if (entry.isDirectory()) {
+      const subHash = await hashDirectory(fullPath);
+      hash.update(subHash);
+    } else if (entry.isFile()) {
+      await new Promise((resolve, reject) => {
+        const stream = fs.createReadStream(fullPath);
+        stream.on("data", (chunk) => hash.update(chunk));
+        stream.on("end", () => resolve());
+        stream.on("error", reject);
+      });
+    }
+  }
+
+  return hash.digest("hex");
+}

--- a/test/fs-hash.js
+++ b/test/fs-hash.js
@@ -1,0 +1,132 @@
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { hashPath } from "../src/fs-hash.js";
+
+describe("hashPath", () => {
+  let tempDir;
+
+  beforeEach(async () => {
+    tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "hash-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("same folder checked twice produces same hash", async () => {
+    const dir = path.join(tempDir, "folder");
+    await fs.promises.mkdir(dir);
+    await fs.promises.writeFile(path.join(dir, "file.txt"), "content");
+
+    const hash1 = await hashPath(dir);
+    const hash2 = await hashPath(dir);
+
+    assert.equal(hash1, hash2);
+  });
+
+  test("same name and content in different parents produces same hash", async () => {
+    const dir1 = path.join(tempDir, "parent1", "folder");
+    await fs.promises.mkdir(dir1, { recursive: true });
+    await fs.promises.writeFile(path.join(dir1, "file.txt"), "content");
+
+    const dir2 = path.join(tempDir, "parent2", "folder");
+    await fs.promises.mkdir(dir2, { recursive: true });
+    await fs.promises.writeFile(path.join(dir2, "file.txt"), "content");
+
+    const hash1 = await hashPath(dir1);
+    const hash2 = await hashPath(dir2);
+
+    assert.equal(hash1, hash2);
+  });
+
+  test("file rename or content change produces different hash", async () => {
+    const dir = path.join(tempDir, "folder");
+    await fs.promises.mkdir(dir);
+    await fs.promises.writeFile(path.join(dir, "file.txt"), "content");
+
+    const hash1 = await hashPath(dir);
+
+    await fs.promises.writeFile(path.join(dir, "file.txt"), "changed");
+    const hash2 = await hashPath(dir);
+    assert.notEqual(hash1, hash2);
+
+    await fs.promises.writeFile(path.join(dir, "file.txt"), "content");
+    await fs.promises.rename(
+      path.join(dir, "file.txt"),
+      path.join(dir, "renamed.txt")
+    );
+    const hash3 = await hashPath(dir);
+    assert.notEqual(hash1, hash3);
+  });
+
+  test("same name but different content produces different hash", async () => {
+    const dir = path.join(tempDir, "folder");
+    await fs.promises.mkdir(dir);
+    await fs.promises.writeFile(path.join(dir, "file.txt"), "content A");
+
+    const hash1 = await hashPath(dir);
+
+    await fs.promises.rm(dir, { recursive: true });
+    await fs.promises.mkdir(dir);
+    await fs.promises.writeFile(path.join(dir, "file.txt"), "content B");
+
+    const hash2 = await hashPath(dir);
+
+    assert.notEqual(hash1, hash2);
+  });
+
+  test("same content but different names produces different hash", async () => {
+    const dir1 = path.join(tempDir, "folder1");
+    await fs.promises.mkdir(dir1);
+    await fs.promises.writeFile(path.join(dir1, "file.txt"), "content");
+
+    const dir2 = path.join(tempDir, "folder2");
+    await fs.promises.mkdir(dir2);
+    await fs.promises.writeFile(path.join(dir2, "file.txt"), "content");
+
+    const hash1 = await hashPath(dir1);
+    const hash2 = await hashPath(dir2);
+
+    assert.notEqual(hash1, hash2);
+  });
+
+  test("same file checked twice has same hash", async () => {
+    const file = path.join(tempDir, "test.txt");
+    await fs.promises.writeFile(file, "content");
+
+    assert.equal(await hashPath(file), await hashPath(file));
+  });
+
+  test("same name and content in different folders has same hash", async () => {
+    await fs.promises.mkdir(path.join(tempDir, "dir1"));
+    await fs.promises.mkdir(path.join(tempDir, "dir2"));
+    const file1 = path.join(tempDir, "dir1", "test.txt");
+    const file2 = path.join(tempDir, "dir2", "test.txt");
+    await fs.promises.writeFile(file1, "content");
+    await fs.promises.writeFile(file2, "content");
+
+    assert.equal(await hashPath(file1), await hashPath(file2));
+  });
+
+  test("different name has different hash", async () => {
+    const file1 = path.join(tempDir, "a.txt");
+    const file2 = path.join(tempDir, "b.txt");
+    await fs.promises.writeFile(file1, "content");
+    await fs.promises.writeFile(file2, "content");
+
+    assert.notEqual(await hashPath(file1), await hashPath(file2));
+  });
+
+  test("different content has different hash", async () => {
+    const file = path.join(tempDir, "test.txt");
+    await fs.promises.writeFile(file, "content1");
+    const hash1 = await hashPath(file);
+
+    await fs.promises.writeFile(file, "content2");
+
+    assert.notEqual(hash1, await hashPath(file));
+  });
+});


### PR DESCRIPTION
We only use a subset of its features and it's the only non-GitHub dependency we use.

Re-implement the features we need and add a small test suite.