### PR TITLE
input: allow empty input for "install" and "pacboy"

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,11 +19,11 @@ inputs:
   install:
     description: 'After installation and/or update, install additional packages through pacman'
     required: false
-    default: false
+    default: ''
   pacboy:
     description: 'After installation and/or update, install additional packages through pacboy'
     required: false
-    default: false
+    default: ''
   release:
     description: 'Retrieve and extract base installation from upstream GitHub Releases'
     required: false

--- a/main.js
+++ b/main.js
@@ -77,8 +77,14 @@ function parseInput() {
   }
   p_msystem = p_msystem.toUpperCase()
 
-  let p_install_list = (p_install === 'false') ? [] : p_install.split(/\s+/);
-  let p_pacboy_list = (p_pacboy === 'false') ? [] : p_pacboy.split(/\s+/);
+  if (p_install === 'false') {
+    core.warning("'install: false' is deprecated, use 'install: \"\"' or omit the input entirely");
+  }
+  let p_install_list = (p_install === 'false') ? [] : p_install.split(/\s+/).filter(s => s.length > 0);
+  if (p_pacboy === 'false') {
+    core.warning("'pacboy: false' is deprecated, use 'pacboy: \"\"' or omit the input entirely");
+  }
+  let p_pacboy_list = (p_pacboy === 'false') ? [] : p_pacboy.split(/\s+/).filter(s => s.length > 0);
 
   const platformcheckseverity_allowed = ['fatal', 'warn'];
   if (!platformcheckseverity_allowed.includes(p_platformcheckseverity)) {


### PR DESCRIPTION
This is useful in case the input is generated and can be empty in some cases.

While at it also change the default to "" instead of "false", and deprecate the old default.

Fixes #589