### PR TITLE
input: make "location" default an empty string

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,7 @@ inputs:
   location:
     description: 'Where to install MSYS2'
     required: false
-    default: 'RUNNER_TEMP'
+    default: ''
   platform-check-severity:
     description: 'What to do when run on an incompatible runner: fatal, warn'
     required: false

--- a/main.js
+++ b/main.js
@@ -97,6 +97,10 @@ function parseInput() {
     throw new Error(`'platform-check-severity' needs to be one of ${ platformcheckseverity_allowed.join(', ') }, got ${p_platformcheckseverity}`);
   }
 
+  if (p_location === 'RUNNER_TEMP') {
+    core.warning("'location: RUNNER_TEMP' is deprecated, use 'location: \"\"' or omit the input entirely");
+  }
+
   let input = new Input();
   input.release = p_release;
   input.update = p_update;
@@ -105,7 +109,7 @@ function parseInput() {
   input.install = p_install_list;
   input.pacboy = p_pacboy_list;
   input.platformcheckseverity = p_platformcheckseverity;
-  input.location = (p_location == "RUNNER_TEMP") ? null : p_location;
+  input.location = (p_location === "RUNNER_TEMP" || p_location === '') ? null : p_location;
   input.cache = p_cache;
   input.usemainmirroronly = p_use_main_mirror_only;
 


### PR DESCRIPTION
Instead of having the special "RUNNER_TEMP" value. "RUNNER_TEMP" still works but is deprecated.

ade51212c2d made an empty string not use the temp dir by accident, which this fixes again.

Similar to #599