### PR TITLE
Update actions/checkout version and MSYS2 setup

### DIFF
--- a/examples/cmake.yml
+++ b/examples/cmake.yml
@@ -27,14 +27,14 @@ jobs:
     steps:
 
     - name: '🧰 Checkout'
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
         persist-credentials: false
 
     - name: '${{ matrix.icon }} Setup MSYS2'
       uses: msys2/setup-msys2@v2
-      with:
+      with:pathum25 
         msystem: ${{matrix.sys}}
         update: true
         install: >-


### PR DESCRIPTION
Skip to main content

Brand Toolkit

/

Brand ToolkitFoundationsLogo

Logo

Our logo represents our brand and helps people recognize us at a glance. As a key part of our identity, it should be used consistently.

Invertocat

We call our logo pictogram the Invertocat — it represents our mascot, the Octocat. It’s our primary logo, and we use it to represent GitHub on all kinds of surfaces: in the product, for attendees at a GitHub event, subscribers to GitHub emails, or someone reading our help documentation.

The standalone invertocat may be used in GitHub-owned environments or where the brand is already clearly established.

Wordmark lockup

We use the lockup, featuring the invertocat and wordmark, in most places. This logo represents the brand in corporate environments for easy recognition. GitHub is always one word with a capitalized G and H. When referring to GitHub the product, company, or service, keep it simple—GitHub.

Color

The Invertocat and our wordmark should only appear in white, black, or in few cases grey or green. Like text, the logo should be legible and pass accessibility requirements in all settings. When in doubt, use the highest contrast option.

The examples here show just the Invertocat logo, but the thinking applies to all logos.

Product lockups

Product-specific lockups like GitHub Copilot or GitHub Security allow distinct products to build their own recognition while maintaining connection to the GitHub ecosystem. Use these lockups anywhere the product needs to stand independently while still being recognizable as part of GitHub.

Occasionally in marketing, launch materials, and anywhere products need clear identification, full product names paired with the GitHub mark are warranted. Environments where GitHub’s platform is obvious, like github.com, can have navigational lockups without the invertocat.

Events and other logos

Event marks like Universe are time-bound experiences that warrant their own visual identity. Use these for event-specific materials, promotional campaigns, swag, and experiences where the event itself is the hero.

Some initiatives lead by GitHub have bespoke sub-brand logos. Initiatives like the ReadME Project — a large community and publishing initiative lead by GitHub — has an entire brand of its own.

Usage

The logo is our most important graphic device. It should sit high in the visual hierarchy — large, with high contrast and no other effects. For more information on usage, see the cobranding page.

Don’t rearrange the elements of the logo.

Don’t use our illustration, mascots or Mona as a substitute for the logo.

Don’t add graphic effects like shadows or gradients.

Don’t place the logo over busy backgrounds.

Don’t mix the color of the logo or use backgrounds that provide insufficient contrast.

Don’t compress distort, skew, stretch, or alter the logo in any way.

Deprecated logos

GitHub’s primary mark, the Invertocat, has gone mostly unchanged since its creation. But from time to time we’ve made updates to its design—quality improvements which often go unnoticed by most. We’ve also updated our logotype a few times, and made changes to how we brand products.

Beginning in 2025, GitHub Copilot no longer has a standalone logo that heros the Copilot icon. See the Copilot page for more on Copilot’s visual approach.

Legal

GITHUB®, the GITHUB® logo design, the INVERTOCAT logo design, OCTOCAT®, and the OCTOCAT® logo design are trademarks of GitHub, Inc., registered in the United States and other countries.

The OCTOCAT design is the exclusive property of GitHub, Inc and has been federally registered with the United States Copyright Office. All rights reserved.

No adaptation or use of any kind of any of our registered trademarks or copyrights, or any other contents of this website, is allowed without the express written permission of GitHub, Inc.

For more information regarding the authorized uses of these items, please contact us.

Do these things

 Link to GitHubUse a permitted GitHub logo to link to GitHub.

 Social buttonUse the Invertocat logo as a social button to link to your GitHub profile or project.

 Show integrationUse a permitted GitHub logo to inform others that your project integrates with GitHub.

 Bl

